### PR TITLE
Perform delta comparison on Qos Profiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Here are the various options for this utility
 | qosProfile | Fully qualified path of a QoS Profile. For example: QoSLibraryName::QoSProfileName | OPTIONAL: The ``` <qos_profile>``` with ``` is_default_qos="true" ``` will be selected OR the default values will be returned for the -qosTag |
 | qosTag | XML tag name who QoS values you want to be fetched. You can also select a subtag by separating it with a '/'. For example: ``` datawriter_qos/history ``` or ``` domain_participant_qos/property ``` | REQUIRED: Allowed values = {datawriter_qos, datareader_qos, topic_qos, domain_participant_qos (participant_qos is being deprecated), publisher_qos, subscriber_qos} |
 | topicName | Can be used with -qosTag = {datawriter_qos, datareader_qos, topic_qos} | OPTIONAL: The default value used with these types will be NULL |
+| deltaProfile | Only show deviations from default QoS configuration | OPTIONAL: All QoS configuration will be show by default |
 | help | Displays all the options of the rtixmloutpututility | OPTIONAL |
 
 You should also add the the location of the ``` lib ``` folder to your PATH (Windows) or DYLD_LIBRARY_PATH (Mac) or LD_LIBRARY_PATH (Linux) if you compiled the utility using ``` -DBUILD_SHARED_LIBS=1 ```

--- a/src/CommandLineArgumentParser.c
+++ b/src/CommandLineArgumentParser.c
@@ -323,14 +323,13 @@ DDS_Boolean RTI_CommandLineArgumentParser_parse_arguments(
             }
         } else if (strcmp(argv[i], RTI_CMD_ARG_QOS_DELTA[0]) == 0) {
             output_values->qos_delta = DDS_BOOLEAN_TRUE;
-            i += 1;
+            i++;
             continue;
         } else {
             printf("[ERROR] Unknown option '%s'. Please run rtixmloutpututility with the %s option "
                     "to see the valid list of options. \n\n", 
                     argv[i], 
                     RTI_CMD_ARG_HELP[0]);
-            i += 1;
             goto done;
         }
     }

--- a/src/CommandLineArgumentParser.c
+++ b/src/CommandLineArgumentParser.c
@@ -51,6 +51,11 @@ const char *RTI_CMD_ARG_TOPIC_NAME[RTI_CMD_ARG_INFO_ARRAY_SIZE] = {
         "-topicName", 
         "Can be used with -qosTag = \"datawriter_qos\" | \"datareader_qos\" | \"topic_qos\"", 
         "OPTIONAL: The default value used with these types will be NULL"};
+const char *RTI_CMD_ARG_QOS_DELTA[RTI_CMD_ARG_INFO_ARRAY_SIZE] = {
+        "-deltaProfile", 
+        "If specified, the utility will output the difference between the selected QoS Profile"
+        "\n\t\t and the default values for the selected -qosTag", 
+        "OPTIONAL: By default the utility outputs all the Qos values of the selected -qosTag"};
 
 void RTI_CommandLineArgumentParser_print_help() 
 {
@@ -64,6 +69,7 @@ void RTI_CommandLineArgumentParser_print_help()
     printf("%s \t %s \n \t\t %s \n\n", RTI_CMD_ARG_PROFILE_PATH[0], RTI_CMD_ARG_PROFILE_PATH[1], RTI_CMD_ARG_PROFILE_PATH[2]);
     printf("%s \t %s \n \t\t %s \n\n", RTI_CMD_ARG_QOS_TAG[0], RTI_CMD_ARG_QOS_TAG[1], RTI_CMD_ARG_QOS_TAG[2]);
     printf("%s \t %s \n \t\t %s \n\n", RTI_CMD_ARG_TOPIC_NAME[0], RTI_CMD_ARG_TOPIC_NAME[1], RTI_CMD_ARG_TOPIC_NAME[2]);
+    printf("%s \t %s \n \t\t %s \n\n", RTI_CMD_ARG_QOS_DELTA[0], RTI_CMD_ARG_QOS_DELTA[1], RTI_CMD_ARG_QOS_DELTA[2]);
     printf("%s \t %s \n \t\t %s \n\n", RTI_CMD_ARG_HELP[0], RTI_CMD_ARG_HELP[1], RTI_CMD_ARG_HELP[2]);
 }
 
@@ -88,6 +94,7 @@ void RTI_CommandLineArguments_initialize(struct RTI_CommandLineArguments *cmd_ar
     cmd_args->query = NULL;
     cmd_args->topic_name = NULL;
     cmd_args->qos_file = NULL;
+    cmd_args->qos_delta = DDS_BOOLEAN_FALSE;
 }
 
 void RTI_CommandLineArguments_finalize(struct RTI_CommandLineArguments *cmd_args)
@@ -99,6 +106,7 @@ void RTI_CommandLineArguments_finalize(struct RTI_CommandLineArguments *cmd_args
     DDS_String_free(cmd_args->query);
     cmd_args->topic_name = NULL;
     cmd_args->qos_file = NULL;
+    // Don't have to do anything for qos_delta
 }
 
 DDS_Boolean RTI_CommandLineArgumentParser_parse_qos_file(
@@ -188,6 +196,8 @@ DDS_Boolean RTI_CommandLineArgumentParser_parse_arguments(
         } else if (!strcmp(argv[i], RTI_CMD_ARG_QOS_FILE[0])) {
             if (RTI_CommandLineArgumentParser_has_value(argc, argv, i)) {
                 output_values->qos_file = argv[i + 1];
+                i += 2;
+                continue;
             } else {
                 printf("[WARN] No value provided for '%s' option! \n\n", 
                         RTI_CMD_ARG_QOS_FILE[0]);
@@ -196,6 +206,8 @@ DDS_Boolean RTI_CommandLineArgumentParser_parse_arguments(
         } else if (strcmp(argv[i], RTI_CMD_ARG_OUTPUT_FILE[0]) == 0) {
             if (RTI_CommandLineArgumentParser_has_value(argc, argv, i)) {
                 output_values->output_file = argv[i + 1];
+                i += 2;
+                continue;
             } else {
                 printf("[WARN] No value provided for '%s' option! \n\n", 
                         RTI_CMD_ARG_OUTPUT_FILE[0]);
@@ -241,6 +253,8 @@ DDS_Boolean RTI_CommandLineArgumentParser_parse_arguments(
                             RTI_CMD_ARG_PROFILE_PATH[0]);
                     goto done;
                 }
+                i += 2;
+                continue;
             } else {
                 printf("[WARN] No value provided for '%s' option! \n\n", 
                         RTI_CMD_ARG_PROFILE_PATH[0]);
@@ -290,6 +304,8 @@ DDS_Boolean RTI_CommandLineArgumentParser_parse_arguments(
                     }
                     strcpy(output_values->qos_type, argv[i + 1]);
                 }
+                i += 2;
+                continue;
             } else {
                 printf("[WARN] No value provided for '%s' option! \n\n", 
                         RTI_CMD_ARG_QOS_TAG[0]);
@@ -298,19 +314,25 @@ DDS_Boolean RTI_CommandLineArgumentParser_parse_arguments(
         } else if (strcmp(argv[i], RTI_CMD_ARG_TOPIC_NAME[0]) == 0) {
             if (RTI_CommandLineArgumentParser_has_value(argc, argv, i)) {
                 output_values->topic_name = argv[i + 1];
+                i += 2;
+                continue;
             } else {
                 printf("[WARN] No value provided for '%s' option! \n\n", 
                         RTI_CMD_ARG_TOPIC_NAME[0]);
                 goto done;
             }
+        } else if (strcmp(argv[i], RTI_CMD_ARG_QOS_DELTA[0]) == 0) {
+            output_values->qos_delta = DDS_BOOLEAN_TRUE;
+            i += 1;
+            continue;
         } else {
             printf("[ERROR] Unknown option '%s'. Please run rtixmloutpututility with the %s option "
                     "to see the valid list of options. \n\n", 
                     argv[i], 
                     RTI_CMD_ARG_HELP[0]);
+            i += 1;
             goto done;
         }
-        i += 2;
     }
 
     if (output_values->qos_type == NULL) {
@@ -357,4 +379,7 @@ void RTI_CommandLineArgumentParser_print_arguments(struct RTI_CommandLineArgumen
     printf("%s \t '%s' \n", 
             RTI_CMD_ARG_TOPIC_NAME[0], 
             values->topic_name == NULL ? "" : values->topic_name);
+    printf("%s \t '%s' \n", 
+            RTI_CMD_ARG_QOS_DELTA[0], 
+            values->qos_delta == DDS_BOOLEAN_TRUE ? "True" : "False");
 }

--- a/src/CommandLineArgumentParser.c
+++ b/src/CommandLineArgumentParser.c
@@ -1,5 +1,5 @@
 /*
- * (c) 2019 Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * (c) 2019-2025 Copyright, Real-Time Innovations, Inc. All rights reserved.
  *
  * RTI grants Licensee a license to use, modify, compile, and create derivative
  * works of the Software.  Licensee has the right to distribute object form

--- a/src/CommandLineArgumentParser.h
+++ b/src/CommandLineArgumentParser.h
@@ -29,6 +29,7 @@ struct RTI_CommandLineArguments {
     char *qos_type;
     const char *topic_name;
     char *query;
+    DDS_Boolean qos_delta;
 };
 
 void RTI_CommandLineArguments_initialize(struct RTI_CommandLineArguments *cmd_args);

--- a/src/CommandLineArgumentParser.h
+++ b/src/CommandLineArgumentParser.h
@@ -1,5 +1,5 @@
 /*
- * (c) 2019 Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * (c) 2019-2025 Copyright, Real-Time Innovations, Inc. All rights reserved.
  *
  * RTI grants Licensee a license to use, modify, compile, and create derivative
  * works of the Software.  Licensee has the right to distribute object form

--- a/src/RTIXMLOutputUtility.c
+++ b/src/RTIXMLOutputUtility.c
@@ -29,6 +29,7 @@ DDS_Boolean RTI_XMLOutputUtility_process_arguments(
                 cmd_args->qos_library, 
                 cmd_args->qos_profile, 
                 cmd_args->topic_name, 
+                cmd_args->qos_delta,
                 xml_save_context)) {
             goto done;
         }
@@ -38,6 +39,7 @@ DDS_Boolean RTI_XMLOutputUtility_process_arguments(
                 cmd_args->qos_library, 
                 cmd_args->qos_profile, 
                 cmd_args->topic_name, 
+                cmd_args->qos_delta,
                 xml_save_context)) {
             goto done;
         }
@@ -47,6 +49,7 @@ DDS_Boolean RTI_XMLOutputUtility_process_arguments(
                 cmd_args->qos_library, 
                 cmd_args->qos_profile, 
                 cmd_args->topic_name, 
+                cmd_args->qos_delta,
                 xml_save_context)) {
             goto done;
         }
@@ -55,6 +58,7 @@ DDS_Boolean RTI_XMLOutputUtility_process_arguments(
                 factory, 
                 cmd_args->qos_library, 
                 cmd_args->qos_profile, 
+                cmd_args->qos_delta,
                 xml_save_context)) {
             goto done;
         }
@@ -63,6 +67,7 @@ DDS_Boolean RTI_XMLOutputUtility_process_arguments(
                 factory, 
                 cmd_args->qos_library, 
                 cmd_args->qos_profile, 
+                cmd_args->qos_delta,
                 xml_save_context)) {
             goto done;
         }
@@ -78,6 +83,7 @@ DDS_Boolean RTI_XMLOutputUtility_process_arguments(
                 factory, 
                 cmd_args->qos_library, 
                 cmd_args->qos_profile, 
+                cmd_args->qos_delta,
                 xml_save_context)) {
             goto done;
         }

--- a/src/RTIXMLOutputUtility.c
+++ b/src/RTIXMLOutputUtility.c
@@ -1,5 +1,5 @@
 /*
- * (c) 2019 Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * (c) 2019-2025 Copyright, Real-Time Innovations, Inc. All rights reserved.
  *
  * RTI grants Licensee a license to use, modify, compile, and create derivative
  * works of the Software.  Licensee has the right to distribute object form

--- a/src/XMLHelper.c
+++ b/src/XMLHelper.c
@@ -99,7 +99,7 @@ DDS_Boolean RTI_XMLHelper_dump_datawriter_qos(
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
 
-    if(qos_delta){
+    if (qos_delta) {
         if (DDS_DataWriterQos_get_defaultI(&base_dw_qos) != DDS_RETCODE_OK) {
             printf("[ERROR] Failed to get the default values for <base_dw_qos>! \n");
             goto done;
@@ -155,7 +155,7 @@ DDS_Boolean RTI_XMLHelper_dump_datareader_qos(
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
 
-    if(qos_delta){
+    if (qos_delta) {
         if (DDS_DataReaderQos_get_defaultI(&base_dr_qos) != DDS_RETCODE_OK) {
             printf("[ERROR] Failed to get the default values for <base_dr_qos>! \n");
             goto done;
@@ -211,7 +211,7 @@ DDS_Boolean RTI_XMLHelper_dump_topic_qos(
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
 
-    if(qos_delta){
+    if (qos_delta) {
         if (DDS_TopicQos_get_defaultI(&base_topic_qos) != DDS_RETCODE_OK) {
             printf("[ERROR] Failed to get the default values for <base_topic_qos>! \n");
             goto done;
@@ -266,7 +266,7 @@ DDS_Boolean RTI_XMLHelper_dump_publisher_qos(
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
 
-    if(qos_delta){
+    if (qos_delta) {
         DDS_PublisherQos_get_defaultI(&base_publisher_qos);
         base_publisher_qos_ptr = &base_publisher_qos;
     }
@@ -313,7 +313,7 @@ DDS_Boolean RTI_XMLHelper_dump_subscriber_qos(
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
 
-    if(qos_delta){
+    if (qos_delta) {
         DDS_SubscriberQos_get_defaultI(&base_subscriber_qos);
         base_subscriber_qos_ptr = &base_subscriber_qos;
     }
@@ -360,7 +360,7 @@ DDS_Boolean RTI_XMLHelper_dump_participant_qos(
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
 
-    if(qos_delta){
+    if (qos_delta) {
         if (DDS_DomainParticipantQos_get_defaultI(&base_participant_qos) != DDS_RETCODE_OK) {
             printf("[ERROR] Failed to get the default values for <base_participant_qos>! \n");
             goto done;

--- a/src/XMLHelper.c
+++ b/src/XMLHelper.c
@@ -1,5 +1,5 @@
 /*
- * (c) 2019 Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * (c) 2019-2025 Copyright, Real-Time Innovations, Inc. All rights reserved.
  *
  * RTI grants Licensee a license to use, modify, compile, and create derivative
  * works of the Software.  Licensee has the right to distribute object form

--- a/src/XMLHelper.c
+++ b/src/XMLHelper.c
@@ -88,13 +88,24 @@ DDS_Boolean RTI_XMLHelper_dump_datawriter_qos(
         char *library_name, 
         char *profile_name, 
         const char *topic_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context) 
 {
     struct DDS_DataWriterQos datawriter_qos = DDS_DataWriterQos_INITIALIZER;
+    struct DDS_DataWriterQos base_dw_qos = DDS_DataWriterQos_INITIALIZER;
+    struct DDS_DataWriterQos *base_dw_qos_ptr = NULL;
     struct DDS_QosPrintFormat printFormat = DDS_QosPrintFormat_INITIALIZER;
     DDS_Boolean result = DDS_BOOLEAN_FALSE;
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
+
+    if(qos_delta){
+        if (DDS_DataWriterQos_get_defaultI(&base_dw_qos) != DDS_RETCODE_OK) {
+            printf("[ERROR] Failed to get the default values for <base_dw_qos>! \n");
+            goto done;
+        }
+        base_dw_qos_ptr = &base_dw_qos;
+    }
 
     if (library_name == NULL || profile_name == NULL) {
         if (DDS_DataWriterQos_get_defaultI(&datawriter_qos) != DDS_RETCODE_OK) {
@@ -116,7 +127,7 @@ DDS_Boolean RTI_XMLHelper_dump_datawriter_qos(
         }
     }
 
-    DDS_DataWriterQos_save(&datawriter_qos, NULL, NULL, context, &printFormat);
+    DDS_DataWriterQos_save(&datawriter_qos, base_dw_qos_ptr, NULL, context, &printFormat);
 
     result = DDS_BOOLEAN_TRUE;
 done:
@@ -133,13 +144,24 @@ DDS_Boolean RTI_XMLHelper_dump_datareader_qos(
         char *library_name, 
         char *profile_name, 
         const char *topic_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context) 
 {
     struct DDS_DataReaderQos datareader_qos = DDS_DataReaderQos_INITIALIZER;
+    struct DDS_DataReaderQos base_dr_qos = DDS_DataReaderQos_INITIALIZER;
+    struct DDS_DataReaderQos *base_dr_qos_ptr = NULL;
     struct DDS_QosPrintFormat printFormat = DDS_QosPrintFormat_INITIALIZER;
     DDS_Boolean result = DDS_BOOLEAN_FALSE;
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
+
+    if(qos_delta){
+        if (DDS_DataReaderQos_get_defaultI(&base_dr_qos) != DDS_RETCODE_OK) {
+            printf("[ERROR] Failed to get the default values for <base_dr_qos>! \n");
+            goto done;
+        }
+        base_dr_qos_ptr = &base_dr_qos;
+    }
 
     if (library_name == NULL || profile_name == NULL) {
         if (DDS_DataReaderQos_get_defaultI(&datareader_qos) != DDS_RETCODE_OK) {
@@ -161,7 +183,7 @@ DDS_Boolean RTI_XMLHelper_dump_datareader_qos(
         }
     }
 
-    DDS_DataReaderQos_save(&datareader_qos, NULL, NULL, context, &printFormat);
+    DDS_DataReaderQos_save(&datareader_qos, base_dr_qos_ptr, NULL, context, &printFormat);
 
     result = DDS_BOOLEAN_TRUE;
 done:
@@ -178,13 +200,24 @@ DDS_Boolean RTI_XMLHelper_dump_topic_qos(
         char *library_name, 
         char *profile_name, 
         const char *topic_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context) 
 {
     struct DDS_TopicQos topic_qos = DDS_TopicQos_INITIALIZER;
+    struct DDS_TopicQos base_topic_qos = DDS_TopicQos_INITIALIZER;
+    struct DDS_TopicQos *base_topic_qos_ptr = NULL;
     struct DDS_QosPrintFormat printFormat = DDS_QosPrintFormat_INITIALIZER;
     DDS_Boolean result = DDS_BOOLEAN_FALSE;
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
+
+    if(qos_delta){
+        if (DDS_TopicQos_get_defaultI(&base_topic_qos) != DDS_RETCODE_OK) {
+            printf("[ERROR] Failed to get the default values for <base_topic_qos>! \n");
+            goto done;
+        }
+        base_topic_qos_ptr = &base_topic_qos;
+    }
 
     if (library_name == NULL || profile_name == NULL) {
         if (DDS_TopicQos_get_defaultI(&topic_qos) != DDS_RETCODE_OK) {
@@ -206,7 +239,7 @@ DDS_Boolean RTI_XMLHelper_dump_topic_qos(
         }
     }
 
-    DDS_TopicQos_save(&topic_qos, NULL, NULL, context, &printFormat);
+    DDS_TopicQos_save(&topic_qos, base_topic_qos_ptr, NULL, context, &printFormat);
 
     result = DDS_BOOLEAN_TRUE;
 done:
@@ -222,13 +255,21 @@ DDS_Boolean RTI_XMLHelper_dump_publisher_qos(
         DDS_DomainParticipantFactory *factory, 
         char *library_name, 
         char *profile_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context) 
 {
     struct DDS_PublisherQos publisher_qos = DDS_PublisherQos_INITIALIZER;
+    struct DDS_PublisherQos base_publisher_qos = DDS_PublisherQos_INITIALIZER;
+    struct DDS_PublisherQos *base_publisher_qos_ptr = NULL;
     struct DDS_QosPrintFormat printFormat = DDS_QosPrintFormat_INITIALIZER;
     DDS_Boolean result = DDS_BOOLEAN_FALSE;
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
+
+    if(qos_delta){
+        DDS_PublisherQos_get_defaultI(&base_publisher_qos);
+        base_publisher_qos_ptr = &base_publisher_qos;
+    }
 
     if (library_name == NULL || profile_name == NULL) {
         DDS_PublisherQos_get_defaultI(&publisher_qos);
@@ -245,7 +286,7 @@ DDS_Boolean RTI_XMLHelper_dump_publisher_qos(
         }
     }
 
-    DDS_PublisherQos_save(&publisher_qos, NULL, NULL, context, &printFormat);
+    DDS_PublisherQos_save(&publisher_qos, base_publisher_qos_ptr, NULL, context, &printFormat);
 
     result = DDS_BOOLEAN_TRUE;
 done:
@@ -261,13 +302,21 @@ DDS_Boolean RTI_XMLHelper_dump_subscriber_qos(
         DDS_DomainParticipantFactory *factory, 
         char *library_name, 
         char *profile_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context) 
 {
     struct DDS_SubscriberQos subscriber_qos = DDS_SubscriberQos_INITIALIZER;
+    struct DDS_SubscriberQos base_subscriber_qos = DDS_SubscriberQos_INITIALIZER;
+    struct DDS_SubscriberQos *base_subscriber_qos_ptr = NULL;
     struct DDS_QosPrintFormat printFormat = DDS_QosPrintFormat_INITIALIZER;
     DDS_Boolean result = DDS_BOOLEAN_FALSE;
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
+
+    if(qos_delta){
+        DDS_SubscriberQos_get_defaultI(&base_subscriber_qos);
+        base_subscriber_qos_ptr = &base_subscriber_qos;
+    }
 
     if (library_name == NULL || profile_name == NULL) {
         DDS_SubscriberQos_get_defaultI(&subscriber_qos);
@@ -284,7 +333,7 @@ DDS_Boolean RTI_XMLHelper_dump_subscriber_qos(
         }
     }
 
-    DDS_SubscriberQos_save(&subscriber_qos, NULL, NULL, context, &printFormat);
+    DDS_SubscriberQos_save(&subscriber_qos, base_subscriber_qos_ptr, NULL, context, &printFormat);
 
     result = DDS_BOOLEAN_TRUE;
 done:
@@ -300,13 +349,24 @@ DDS_Boolean RTI_XMLHelper_dump_participant_qos(
         DDS_DomainParticipantFactory *factory, 
         char *library_name, 
         char *profile_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context) 
 {
     struct DDS_DomainParticipantQos participant_qos = DDS_DomainParticipantQos_INITIALIZER;
+    struct DDS_DomainParticipantQos base_participant_qos = DDS_DomainParticipantQos_INITIALIZER;
+    struct DDS_DomainParticipantQos *base_participant_qos_ptr = NULL;
     struct DDS_QosPrintFormat printFormat = DDS_QosPrintFormat_INITIALIZER;
     DDS_Boolean result = DDS_BOOLEAN_FALSE;
 
     printFormat.print_private = DDS_BOOLEAN_TRUE;
+
+    if(qos_delta){
+        if (DDS_DomainParticipantQos_get_defaultI(&base_participant_qos) != DDS_RETCODE_OK) {
+            printf("[ERROR] Failed to get the default values for <base_participant_qos>! \n");
+            goto done;
+        }
+        base_participant_qos_ptr = &base_participant_qos;
+    }
 
     if (library_name == NULL || profile_name == NULL) {
         if (DDS_DomainParticipantQos_get_defaultI(&participant_qos) != DDS_RETCODE_OK) {
@@ -326,7 +386,7 @@ DDS_Boolean RTI_XMLHelper_dump_participant_qos(
         }
     }
 
-    DDS_DomainParticipantQos_save(&participant_qos, NULL, NULL, context, &printFormat);
+    DDS_DomainParticipantQos_save(&participant_qos, base_participant_qos_ptr, NULL, context, &printFormat);
 
     result = DDS_BOOLEAN_TRUE;
 done:

--- a/src/XMLHelper.h
+++ b/src/XMLHelper.h
@@ -1,5 +1,5 @@
 /*
- * (c) 2019 Copyright, Real-Time Innovations, Inc. All rights reserved.
+ * (c) 2019-2025 Copyright, Real-Time Innovations, Inc. All rights reserved.
  *
  * RTI grants Licensee a license to use, modify, compile, and create derivative
  * works of the Software.  Licensee has the right to distribute object form

--- a/src/XMLHelper.h
+++ b/src/XMLHelper.h
@@ -25,6 +25,7 @@ DDS_Boolean RTI_XMLHelper_dump_datawriter_qos(
         char *library_name, 
         char *profile_name, 
         const char *topic_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context);
 
 DDS_Boolean RTI_XMLHelper_dump_datareader_qos(
@@ -32,6 +33,7 @@ DDS_Boolean RTI_XMLHelper_dump_datareader_qos(
         char *library_name, 
         char *profile_name, 
         const char *topic_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context);
 
 DDS_Boolean RTI_XMLHelper_dump_topic_qos(
@@ -39,24 +41,28 @@ DDS_Boolean RTI_XMLHelper_dump_topic_qos(
         char *library_name, 
         char *profile_name, 
         const char *topic_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context);
 
 DDS_Boolean RTI_XMLHelper_dump_publisher_qos(
         DDS_DomainParticipantFactory *factory, 
         char *library_name, 
         char *profile_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context);
 
 DDS_Boolean RTI_XMLHelper_dump_subscriber_qos(
         DDS_DomainParticipantFactory *factory, 
         char *library_name, 
         char *profile_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context);
 
 DDS_Boolean RTI_XMLHelper_dump_participant_qos(
         DDS_DomainParticipantFactory *factory, 
         char *library_name, 
         char *profile_name, 
+        DDS_Boolean qos_delta,
         struct RTIXMLSaveContext *context);
 
 /* Forward declarations of RTIXMLUTILS functions */


### PR DESCRIPTION
Add a command line argument `deltaProfile` to output the delta from the default instead of output for all Qos config.